### PR TITLE
Drop haml_lint dependency for now.

### DIFF
--- a/manageiq-style.gemspec
+++ b/manageiq-style.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "haml_lint", "~> 0.35.0"
   spec.add_runtime_dependency "rubocop",   "~> 0.82.0"
   spec.add_runtime_dependency "rubocop-performance"
   spec.add_runtime_dependency "rubocop-rails"


### PR DESCRIPTION
It pulls in haml which is a problem for manageiq-ui-classic
See https://github.com/ManageIQ/manageiq/pull/20185#issuecomment-639570950