### PR TITLE
exclude list needs to be in quotes to work

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -5,8 +5,8 @@ require:
 AllCops:
   NewCops: disable
   Exclude:
-    - spec/manageiq/**/*
-    - vendor/**/*
+    - 'spec/manageiq/**/*'
+    - 'vendor/**/*'
   TargetRubyVersion: 2.5
 Layout/HashAlignment:
   EnforcedHashRocketStyle: table


### PR DESCRIPTION
I think the syntax here needs quotes; it worked when I tested locally. 
Anyone willing to give me a test run here and see? 

```
AllCops:
  Exclude:
    - 'node_modules/**/*'
    - 'vendor/**/*'
    - 'spec/**/*'
    - 'app/**/*'
    - 'lib/**/*'
```
in local rubocop yaml should exclude properly. 

Might fix https://github.com/ManageIQ/manageiq-style/issues/7, might also close https://github.com/ManageIQ/manageiq-style/pull/8