### PR TITLE
[VOTE] Disable Lint/RescueException

### DIFF
--- a/styles/base.yml
+++ b/styles/base.yml
@@ -27,6 +27,8 @@ Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 Lint/RaiseException:
   Enabled: true
+Lint/RescueException:
+  Enabled: false
 Lint/StructNewOverride:
   Enabled: true
 Metrics/AbcSize:


### PR DESCRIPTION
This PR disables the [`Lint/RescueException`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RescueException) warning from the linter. Specifically, this will disable warnings like these:

```
Lint/RescueException: Avoid rescuing the Exception class. Perhaps you meant to rescue StandardError?
    rescue Exception => err
```

These types of rescue's permeate both the core code and most of the provider code since we are often using 3rd party libs and cannot necessarily predict what type of exception we need to catch, and absolutely do not want the app to crash. We cannot undo those without risking serious breakage of the app so I believe we should just disable it.

Please vote
- :+1: if you agree (disable the linter)
- :-1: if you disagree (leave the linter as is with the default value of enabled)
- 😕 if you prefer explicit (add the section to the config, but set it to enabled explicitly)
- 🚀 if you prefer to temporary disable (merge this PR, but revert sometime in the future once all of the offenders are updated)