### PR TITLE
[Layout/ExtraSpacing] Exclude Gemfile

### DIFF
--- a/styles/base.yml
+++ b/styles/base.yml
@@ -17,6 +17,8 @@ Layout/EndAlignment:
   AutoCorrect: true
 Layout/ExtraSpacing:
   AutoCorrect: true
+  Exclude:
+    - Gemfile
 Layout/LineLength:
   Enabled: false
 Layout/SpaceAroundMethodCallOperator:


### PR DESCRIPTION
We do a bunch of extra spacing to align our Gemfiles neatly:

https://github.com/ManageIQ/manageiq/pull/20997

So exclude this commonly across the org so it doesn't provide false positives.