### PR TITLE
Bump rubocop to 1.13

### DIFF
--- a/manageiq-style.gemspec
+++ b/manageiq-style.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "more_core_extensions"
   spec.add_runtime_dependency "optimist"
-  spec.add_runtime_dependency "rubocop",   "~> 0.82.0"
+  spec.add_runtime_dependency "rubocop",   "~> 1.13"
   spec.add_runtime_dependency "rubocop-performance"
   spec.add_runtime_dependency "rubocop-rails"
 

--- a/styles/base.yml
+++ b/styles/base.yml
@@ -7,6 +7,7 @@ AllCops:
   Exclude:
     - spec/manageiq/**/*
     - vendor/**/*
+  SuggestExtensions: false
   TargetRubyVersion: 2.5
 Layout/HashAlignment:
   EnforcedHashRocketStyle: table

--- a/styles/base.yml
+++ b/styles/base.yml
@@ -8,7 +8,7 @@ AllCops:
     - spec/manageiq/**/*
     - vendor/**/*
   SuggestExtensions: false
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 Layout/HashAlignment:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table

--- a/styles/base.yml
+++ b/styles/base.yml
@@ -253,6 +253,8 @@ Style/MethodCallWithArgsParentheses:
     - task
 Style/NegatedIf:
   Enabled: false
+Style/NegatedIfElseCondition:
+  Enabled: false
 Style/NumericLiterals:
   AutoCorrect: false
 Style/NumericPredicate:

--- a/styles/base.yml
+++ b/styles/base.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  NewCops: disable
+  NewCops: enable
   Exclude:
     - spec/manageiq/**/*
     - vendor/**/*


### PR DESCRIPTION
I'm not sure what else we need to do in coordination with miq_bot, but the current style.yml works with the latest rubocop