### PR TITLE
Fix codeclimate failing on ruby 2.5 syntax

### DIFF
--- a/styles/cc_base.yml
+++ b/styles/cc_base.yml
@@ -4,7 +4,7 @@
 #
 ---
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 Bundler:
   Enabled: true
 Gemspec:


### PR DESCRIPTION
Currently if you use a rescue in e.g. an if block without a begin
codeclimate will fail with `unexpected token kRESCUE (Using Ruby 2.4
parser; configure using TargetRubyVersion parameter, under AllCops`

If you add `begin; code; rescue` for 2.4 then miq-bot/rubocop will yell
at you, so you really can't win.

Update the codeclimate rubocop base yaml's TargetRubyVersion to match
the one in styles/base.yml