### PR TITLE
Add Rubocop patch version to CC support check

### DIFF
--- a/lib/manageiq/style/cli.rb
+++ b/lib/manageiq/style/cli.rb
@@ -233,7 +233,7 @@ module ManageIQ
       end
 
       def cc_rubocop_channel
-        @cc_rubocop_channel ||= "rubocop-#{rubocop_version.segments[0]}-#{rubocop_version.segments[1]}"
+        @cc_rubocop_channel ||= "rubocop-#{rubocop_version.segments[0]}-#{rubocop_version.segments[1]}-#{rubocop_version.segments[2]}"
       end
 
       def rubocop_version


### PR DESCRIPTION
CodeClimate Rubocop channel branches now include patch version (for
example, `channel/rubocop-1-20-0`).

GitHub view of the example:
https://github.com/codeclimate/codeclimate-rubocop/tree/channel/rubocop-1-20-0