### PR TITLE
Disable Style/QuotedSymbols

### DIFF
--- a/styles/base.yml
+++ b/styles/base.yml
@@ -266,6 +266,8 @@ Style/PerlBackrefs:
   Enabled: false
 Style/ParallelAssignment:
   Enabled: false
+Style/QuotedSymbols:
+  Enabled: false # disabled because Style/StringLiterals is disabled
 Style/RedundantReturn:
   AllowMultipleReturnValues: true
 Style/RegexpLiteral:
@@ -283,7 +285,7 @@ Style/SingleLineMethods:
 Style/SpecialGlobalVars:
   AutoCorrect: false
 Style/StringLiterals:
-  Enabled: false
+  Enabled: false # Also see Style/QuotedSymbols
 Style/StringLiteralsInInterpolation:
   Enabled: false
 Style/SymbolArray:


### PR DESCRIPTION
From the docs:

    By default uses the same configuration as Style/StringLiterals; if
    that cop is not enabled, the default EnforcedStyle is single_quotes.

Since we have disabled Style/StringLiterals, Style/QuotedSymbols is enforcing single quotes, which goes against our choice of disabling enforcement of quoting style, so this commit disables it to match.

@agrare Please review.  I saw this in one of your PRs.