### PR TITLE
Revert "Drop Ruby 2.7"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+        - '2.7'
         - '3.0'
         - '3.1'
         - '3.2'

--- a/manageiq-style.gemspec
+++ b/manageiq-style.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/ManageIQ/manageiq-style"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
One possible solution to #48 
In response to https://github.com/ManageIQ/floe/pull/184

This reverts commit 244dfe6506be674573b9e629eddc5a9e767015ca.
