### PR TITLE
Drop ruby requirement from gemspec

### DIFF
--- a/manageiq-style.gemspec
+++ b/manageiq-style.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/ManageIQ/manageiq-style"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
The Ruby requirement will ultimately come from whatever version of
rubocop we use, so there's no need for us to pin it here. It turns out
that rubocop 1.56.3 require Ruby 2.7, but having it here makes it appear
like a decision of manageiq-style as opposed to the restriction coming
from rubocop itself.

@kbrock Please review.