### PR TITLE
Enforce a minimum version for rack for CVEs

### DIFF
--- a/manageiq-style.gemspec
+++ b/manageiq-style.gemspec
@@ -28,11 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rubocop", "= 1.56.3"
   spec.add_runtime_dependency "rubocop-performance"
   spec.add_runtime_dependency "rubocop-rails"
-  # style depends upon rubocop
-  # rubocop depends upon rexml.
-  #   minimum rexml version is here for CVE-2024-49761
-  #   remove after upgrading rubocop. (newer versions no longer depend upon rexml)
-  spec.add_runtime_dependency "rexml", ">= 3.3.9"
+
+  spec.add_runtime_dependency "rexml", ">= 3.3.9"  # rubocop depends on rexml. Enforce a minimum for CVE-2024-49761
+  spec.add_runtime_dependency "rack", ">= 3.1.12"  # rubocop-rails depends on rack. Enforce a minimum for CVE-2025-27610
 
   spec.add_development_dependency "rake",      "~> 12.0"
   spec.add_development_dependency "rspec",     "~> 3.0"


### PR DESCRIPTION
@kbrock Please review.  This should help in fixing a lot of the rack CVEs across our various gems.

If I cut this and update the repos, I think this will fix all of
- ManageIQ/activerecord-virtual_attributes#180
- ManageIQ/amazon_ssa_support#134
- ManageIQ/httpd_configmap_generator#93
- ManageIQ/manageiq-appliance_console#276
- ManageIQ/manageiq-gems-pending#604
- ManageIQ/manageiq-loggers#89
- ManageIQ/manageiq-rpm_build#558
- ManageIQ/manageiq-schema#786
- ManageIQ/multi_repo#44
- ManageIQ/optimist#176
- ManageIQ/vmware_web_service#146