### PR TITLE
Loosen rack dependency down to the 2.2 range, but only to safe versions

### DIFF
--- a/manageiq-style.gemspec
+++ b/manageiq-style.gemspec
@@ -30,7 +30,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rubocop-rails"
 
   spec.add_runtime_dependency "rexml", ">= 3.3.9"  # rubocop depends on rexml. Enforce a minimum for CVE-2024-49761
-  spec.add_runtime_dependency "rack", ">= 3.1.12"  # rubocop-rails depends on rack. Enforce a minimum for CVE-2025-27610
+
+  # rubocop-rails depends on rack. Enforce a minimum of 2.2.13, 3.0.14, or 3.1.12 for CVE-2025-27610
+  spec.add_runtime_dependency "rack", ">= 2.2.13", *("!= 3.0.0".."!= 3.0.9"), "!= 3.0.4.1", "!= 3.0.4.2", "!= 3.0.6.1", "!= 3.0.9.1", *("!= 3.0.10".."!= 3.0.13"), *("!= 3.1.0".."!= 3.1.9"), *("!= 3.1.10".."!= 3.1.11"), "< 4"
 
   spec.add_development_dependency "rake",      "~> 12.0"
   spec.add_development_dependency "rspec",     "~> 3.0"


### PR DESCRIPTION
It turns out Rails 7.0 uses rack at the 2.2 range, so the change in #59 created a conflict.  I really just want to lock to safe versions of rack, so this can do that.

This is gross, but I can't figure out a better way to do this.

Note that I have to split the ranges like `*("!= 3.1.0".."!= 3.1.9"), *("!= 3.1.10".."!= 3.1.11")` as opposed to `*("!= 3.1.0".."!= 3.1.11")` is because the latter does the following:

```
[3] pry(main)> [*("!= 3.1.0".."!= 3.1.11")].size
=> 9690
[4] pry(main)> [*("!= 3.1.0".."!= 3.1.11")].last
=> "!= 99.9.9"
```

since this is actually String#succ.  There's probably a cute way to do it with a Version class, but this is how I did it in core for bundler, and it's fairly readable and way less wordy than one by one listing.

This is what the resolution looks like in Gemfile.lock

```
PATH
  remote: .
  specs:
    manageiq-style (1.5.4)
      more_core_extensions
      optimist
      rack (>= 2.2.13, < 4, != 3.1.9, != 3.1.8, != 3.1.7, != 3.1.6, != 3.1.5, != 3.1.4, != 3.1.3, != 3.1.2, != 3.1.11, != 3.1.10, != 3.1.1, != 3.1.0, != 3.0.9.1, != 3.0.9, != 3.0.8, != 3.0.7, != 3.0.6.1, != 3.0.6, != 3.0.5, != 3.0.4.2, != 3.0.4.1, != 3.0.4, != 3.0.3, != 3.0.2, != 3.0.13, != 3.0.12, != 3.0.11, != 3.0.10, != 3.0.1, != 3.0.0)
      rexml (>= 3.3.9)
      rubocop (= 1.56.3)
      rubocop-performance
      rubocop-rails
```