### PR TITLE
Lockdown rubocop-ast to the last version before the deprecation warnings

### DIFF
--- a/manageiq-style.gemspec
+++ b/manageiq-style.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "more_core_extensions"
   spec.add_runtime_dependency "optimist"
   spec.add_runtime_dependency "rubocop", "= 1.56.3"
+  spec.add_runtime_dependency "rubocop-ast", "~> 1.40.0"
   spec.add_runtime_dependency "rubocop-performance"
   spec.add_runtime_dependency "rubocop-rails"
 


### PR DESCRIPTION
This avoid the changes in https://github.com/rubocop/rubocop-ast/commit/be16c46719657eee7f21d269009320933d02248b

To verify this you just need code with an ensure block, such as

```ruby
begin
  puts "Hi"
ensure
  puts " There"
end
```

@kbrock Please review.