### PR TITLE
Various style updates

### DIFF
--- a/lib/manageiq/style/cli.rb
+++ b/lib/manageiq/style/cli.rb
@@ -40,9 +40,7 @@ module ManageIQ
         update_gem_source
       end
 
-      private
-
-      def update_rubocop_yml(file = ".rubocop.yml")
+      private def update_rubocop_yml(file = ".rubocop.yml")
         data = begin
           YAML.load_file(file)
         rescue Errno::ENOENT
@@ -55,17 +53,17 @@ module ManageIQ
         File.write(file, data.to_yaml.sub("---\n", ""))
       end
 
-      def ensure_rubocop_local_yml_exists(file = ".rubocop_local.yml")
+      private def ensure_rubocop_local_yml_exists(file = ".rubocop_local.yml")
         FileUtils.touch(file)
       end
 
-      def ensure_haml_lint_yml(file = ".haml-lint.yml")
+      private def ensure_haml_lint_yml(file = ".haml-lint.yml")
         return if File.exist?(file)
 
         FileUtils.ln_s(".rubocop.yml", file)
       end
 
-      def update_yamllint(file = ".yamllint")
+      private def update_yamllint(file = ".yamllint")
         data = begin
           YAML.load_file(file)
         rescue Errno::ENOENT
@@ -85,7 +83,7 @@ module ManageIQ
         File.write(file, data.to_yaml.sub("---\n", ""))
       end
 
-      def update_gem_source
+      private def update_gem_source
         if (gemspec = Dir.glob("*.gemspec").first)
           update_gemspec(gemspec)
         elsif File.exist?("Gemfile")
@@ -93,7 +91,7 @@ module ManageIQ
         end
       end
 
-      def update_gemspec(gemspec)
+      private def update_gemspec(gemspec)
         contents = File.read(gemspec)
         return if contents.include?("manageiq-style")
 
@@ -127,7 +125,7 @@ module ManageIQ
         File.write(gemspec, lines.join)
       end
 
-      def update_gemfile
+      private def update_gemfile
         contents = File.read("Gemfile")
         return if contents.include?("manageiq-style")
 
@@ -172,7 +170,7 @@ module ManageIQ
         File.write("Gemfile", lines.join)
       end
 
-      def format_gem_source_lines!(lines)
+      private def format_gem_source_lines!(lines)
         indent = lines.first.match(/^\s+/).to_s
 
         lines.map! { |l| l.strip.gsub(/[()]/, " ").split(" ", 3) }             # Split to [prefix, gem, versions]
@@ -184,7 +182,7 @@ module ManageIQ
         lines
       end
 
-      def update_generator
+      private def update_generator
         plugin_dir = "lib/generators/manageiq/plugin/templates"
 
         return unless File.directory?(plugin_dir)
@@ -193,7 +191,7 @@ module ManageIQ
         ensure_rubocop_local_yml_exists(File.join(plugin_dir, ".rubocop_local.yml"))
       end
 
-      def rubocop_version
+      private def rubocop_version
         @rubocop_version ||= begin
           require 'rubocop'
           Gem::Version.new(RuboCop::Version.version)

--- a/styles/base.yml
+++ b/styles/base.yml
@@ -21,8 +21,6 @@ Layout/ExtraSpacing:
     - Gemfile
 Layout/LineLength:
   Enabled: false
-Layout/SpaceBeforeFirstArg:
-  Enabled: false
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 Metrics:
@@ -42,18 +40,15 @@ Rails/FindEach:
 Rails/HttpStatus:
   EnforcedStyle: numeric
 Style/AccessModifierDeclarations:
-  Enabled: false
+  EnforcedStyle: inline
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/ClassCheck:
   EnforcedStyle: kind_of?
 Style/CollectionMethods:
-  # Enabled: true
+  Enabled: true
   PreferredMethods:
     find: detect
-    find_all: select
-    map: collect
-    reduce: inject
 Style/Documentation:
   Enabled: false
 Style/DoubleNegation:
@@ -68,23 +63,18 @@ Style/FormatStringToken:
   EnforcedStyle: template
 Style/FrozenStringLiteralComment:
   Enabled: false
-Style/GuardClause:
-  Enabled: false
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
   Exclude:
     - db/schema.rb
-Style/IfUnlessModifier:
-  Enabled: false
 Style/MethodCallWithArgsParentheses:
+  Enabled: true
   Exclude:
     - Gemfile
     - config/routes.rb
     - lib/generators/**/*
-    - lib/resource_feeder/**/*
     - lib/tasks/**/*
     - spec/**/*
-  Enabled: true
   AllowedMethods:
     # Ruby
     - add_dependency
@@ -222,13 +212,7 @@ Style/MethodCallWithArgsParentheses:
     # Rake
     - desc
     - task
-Style/NegatedIf:
-  Enabled: false
-Style/NegatedIfElseCondition:
-  Enabled: false
 Style/NumericPredicate:
-  Enabled: false
-Style/ParallelAssignment:
   Enabled: false
 Style/PerlBackrefs:
   Enabled: false
@@ -238,15 +222,13 @@ Style/RedundantReturn:
   AllowMultipleReturnValues: true
 Style/RegexpLiteral:
   Enabled: false
-Style/RescueStandardError:
-  EnforcedStyle: implicit
 Style/SingleLineMethods:
   AllowIfMethodIsEmpty: false
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_builtin_english_names
 Style/StringLiterals:
   Enabled: false # Also see Style/QuotedSymbols
 Style/StringLiteralsInInterpolation:
-  Enabled: false
-Style/SymbolArray:
   Enabled: false
 Style/TrailingCommaInArrayLiteral:
   Enabled: false
@@ -255,6 +237,4 @@ Style/TrailingCommaInHashLiteral:
 Style/TrailingUnderscoreVariable:
   Enabled: false
 Style/WhileUntilModifier:
-  Enabled: false
-Style/WordArray:
   Enabled: false


### PR DESCRIPTION
As discussed offline with @ManageIQ/core-admins.

For the following I want to move back to the default of enabled (we have it disabled for some reason)

- [Layout/SpaceBeforeFirstArg](https://docs.rubocop.org/rubocop/latest/cops_layout.html#layoutspacebeforefirstarg)
- [Style/GuardClause](https://docs.rubocop.org/rubocop/latest/cops_style.html#styleguardclause)
- [Style/IfUnlessModifier](https://docs.rubocop.org/rubocop/latest/cops_style.html#styleifunlessmodifier)
- [Style/NegatedIf](https://docs.rubocop.org/rubocop/latest/cops_style.html#stylenegatedif)
- [Style/NegatedIfElseCondition](https://docs.rubocop.org/rubocop/latest/cops_style.html#stylenegatedifelsecondition)
- [Style/ParallelAssignment](https://docs.rubocop.org/rubocop/latest/cops_style.html#styleparallelassignment)
- [Style/SymbolArray](https://docs.rubocop.org/rubocop/latest/cops_style.html#stylesymbolarray)
- [Style/WordArray](https://docs.rubocop.org/rubocop/latest/cops_style.html#stylewordarray)


Also

- [Style/AccessModifierDeclarations](https://docs.rubocop.org/rubocop/latest/cops_style.html#styleaccessmodifierdeclarations).  Right now it's disabled - I want to Enable and set to inline
  As I've been writing more Ruby I really like the explicitness in:

   ```ruby
   private def foo
   private def bar
   ```

   vs

   ```ruby
   private

   def foo
   def bar
   ```
- [Style/CollectionMethods](https://docs.rubocop.org/rubocop/latest/cops_style.html#stylecollectionmethods) - default is disabled, we had it configured so I assume we want enabled - also I want to change [our configuration](https://github.com/ManageIQ/manageiq-style/blob/master/styles/base.yml#L84-L87) back to the default, except prefer .detect over .find
- [Style/RescueStandardError](https://docs.rubocop.org/rubocop/latest/cops_style.html#stylerescuestandarderror) - want to go back to the default of explicit (we have it configured as implicit )
- [Style/SpecialGlobalVars](https://docs.rubocop.org/rubocop/latest/cops_style.html#stylespecialglobalvars) - we have it enabled, but I want to change the setting to `use_builtin_english_names`, cause I find the named global vars annoying in that you have to pull in the English library.